### PR TITLE
Similarity transforms

### DIFF
--- a/src/main/java/itc/converters/ElastixAffine2DToAffineTransform2D.java
+++ b/src/main/java/itc/converters/ElastixAffine2DToAffineTransform2D.java
@@ -60,13 +60,13 @@ public class ElastixAffine2DToAffineTransform2D
 
 		// convert
 		//
-		final double[] rotationCentrePositive = new double[ 2 ];
-		final double[] rotationCentreNegative = new double[ 2 ];
+		final double[] rotationCenterPositive = new double[ 2 ];
+		final double[] rotationCenterNegative = new double[ 2 ];
 
 		for ( int d = 0; d < 2; ++d )
 		{
-			rotationCentrePositive[ d ] = rotationCenterInMillimeters[ d ];
-			rotationCentreNegative[ d ] = - rotationCenterInMillimeters[ d ];
+			rotationCenterPositive[ d ] = rotationCenterInMillimeters[ d ];
+			rotationCenterNegative[ d ] = - rotationCenterInMillimeters[ d ];
 		}
 
 		final AffineTransform2D transform2D = new AffineTransform2D();
@@ -74,8 +74,8 @@ public class ElastixAffine2DToAffineTransform2D
 		// rotate and scale
 		//
 
-		// translate to rotation centre
-		transform2D.translate( rotationCentreNegative );
+		// translate to rotation center
+		transform2D.translate( rotationCenterNegative );
 
 		// rotate and scale
 		final AffineTransform2D rotateAndScale = new AffineTransform2D();
@@ -89,11 +89,11 @@ public class ElastixAffine2DToAffineTransform2D
 
 		transform2D.preConcatenate( rotateAndScale );
 
-		// translate back from rotation centre
-		final AffineTransform2D translateBackFromRotationCentre = new AffineTransform2D();
-		translateBackFromRotationCentre.translate( rotationCentrePositive );
+		// translate back from rotation center
+		final AffineTransform2D translateBackFromRotationCenter = new AffineTransform2D();
+		translateBackFromRotationCenter.translate( rotationCenterPositive );
 
-		transform2D.preConcatenate( translateBackFromRotationCentre );
+		transform2D.preConcatenate( translateBackFromRotationCenter );
 
 		// translate
 		//

--- a/src/main/java/itc/converters/ElastixAffine3DToAffineTransform3D.java
+++ b/src/main/java/itc/converters/ElastixAffine3DToAffineTransform3D.java
@@ -60,13 +60,13 @@ public class ElastixAffine3DToAffineTransform3D
 
 		// convert
 		//
-		final double[] rotationCentrePositive = new double[ 3 ];
-		final double[] rotationCentreNegative = new double[ 3 ];
+		final double[] rotationCenterPositive = new double[ 3 ];
+		final double[] rotationCenterNegative = new double[ 3 ];
 
 		for ( int d = 0; d < 3; ++d )
 		{
-			rotationCentrePositive[ d ] = rotationCenterInMillimeters[ d ];
-			rotationCentreNegative[ d ] = - rotationCenterInMillimeters[ d ];
+			rotationCenterPositive[ d ] = rotationCenterInMillimeters[ d ];
+			rotationCenterNegative[ d ] = - rotationCenterInMillimeters[ d ];
 		}
 
 		final AffineTransform3D transform3D = new AffineTransform3D();
@@ -74,8 +74,8 @@ public class ElastixAffine3DToAffineTransform3D
 		// rotate and scale
 		//
 
-		// translate to rotation centre
-		transform3D.translate( rotationCentreNegative );
+		// translate to rotation center
+		transform3D.translate( rotationCenterNegative );
 
 		// rotate and scale
 		final AffineTransform3D rotateAndScale = new AffineTransform3D();
@@ -89,11 +89,11 @@ public class ElastixAffine3DToAffineTransform3D
 
 		transform3D.preConcatenate( rotateAndScale );
 
-		// translate back from rotation centre
-		final AffineTransform3D translateBackFromRotationCentre = new AffineTransform3D();
-		translateBackFromRotationCentre.translate( rotationCentrePositive );
+		// translate back from rotation center
+		final AffineTransform3D translateBackFromRotationCenter = new AffineTransform3D();
+		translateBackFromRotationCenter.translate( rotationCenterPositive );
 
-		transform3D.preConcatenate( translateBackFromRotationCentre );
+		transform3D.preConcatenate( translateBackFromRotationCenter );
 
 		// translate
 		//

--- a/src/main/java/itc/converters/ElastixEuler2DToAffineTransform2D.java
+++ b/src/main/java/itc/converters/ElastixEuler2DToAffineTransform2D.java
@@ -59,30 +59,30 @@ public class ElastixEuler2DToAffineTransform2D
 
         // convert
         //
-        final double[] rotationCentrePositive = new double[ 2 ];
-        final double[] rotationCentreNegative = new double[ 2 ];
+        final double[] rotationCenterPositive = new double[ 2 ];
+        final double[] rotationCenterNegative = new double[ 2 ];
 
         for ( int d = 0; d < 2; ++d )
         {
-            rotationCentrePositive[ d ] = rotationCenterInMillimeters[ d ];
-            rotationCentreNegative[ d ] = - rotationCenterInMillimeters[ d ];
+            rotationCenterPositive[ d ] = rotationCenterInMillimeters[ d ];
+            rotationCenterNegative[ d ] = - rotationCenterInMillimeters[ d ];
         }
 
         final AffineTransform2D transform2D = new AffineTransform2D();
 
-        // rotate around rotation centre
+        // rotate around rotation center
         //
 
-        // translate to rotation centre
-        transform2D.translate( rotationCentreNegative );
+        // translate to rotation center
+        transform2D.translate( rotationCenterNegative );
 
         // rotate
         transform2D.rotate( angle );
 
-        // move image centre back
-        final AffineTransform2D translateBackFromRotationCentre = new AffineTransform2D();
-        translateBackFromRotationCentre.translate( rotationCentrePositive );
-        transform2D.preConcatenate( translateBackFromRotationCentre );
+        // move image center back
+        final AffineTransform2D translateBackFromRotationCenter = new AffineTransform2D();
+        translateBackFromRotationCenter.translate( rotationCenterPositive );
+        transform2D.preConcatenate( translateBackFromRotationCenter );
 
         // translate
         //

--- a/src/main/java/itc/converters/ElastixEuler3DToAffineTransform3D.java
+++ b/src/main/java/itc/converters/ElastixEuler3DToAffineTransform3D.java
@@ -68,31 +68,31 @@ public class ElastixEuler3DToAffineTransform3D
 
 		// convert
 		//
-		final double[] rotationCentrePositive = new double[ 3 ];
-		final double[] rotationCentreNegative = new double[ 3 ];
+		final double[] rotationCenterPositive = new double[ 3 ];
+		final double[] rotationCenterNegative = new double[ 3 ];
 
 		for ( int d = 0; d < 3; ++d )
 		{
-			rotationCentrePositive[ d ] = rotationCenterInMillimeters[ d ];
-			rotationCentreNegative[ d ] = - rotationCenterInMillimeters[ d ];
+			rotationCenterPositive[ d ] = rotationCenterInMillimeters[ d ];
+			rotationCenterNegative[ d ] = - rotationCenterInMillimeters[ d ];
 		}
 
 		final AffineTransform3D transform3D = new AffineTransform3D();
 
-		// rotate around rotation centre
+		// rotate around rotation center
 		//
 
-		// make rotation centre the image centre
-		transform3D.translate( rotationCentreNegative );
+		// make rotation center the image center
+		transform3D.translate( rotationCenterNegative );
 
 		// rotate
 		for ( int d = 0; d < 3; ++d )
 			transform3D.rotate( d, angles[ d ]);
 
-		// move image centre back
-		final AffineTransform3D translateBackFromRotationCentre = new AffineTransform3D();
-		translateBackFromRotationCentre.translate( rotationCentrePositive );
-		transform3D.preConcatenate( translateBackFromRotationCentre );
+		// move image center back
+		final AffineTransform3D translateBackFromRotationCenter = new AffineTransform3D();
+		translateBackFromRotationCenter.translate( rotationCenterPositive );
+		transform3D.preConcatenate( translateBackFromRotationCenter );
 
 		// translate
 		//

--- a/src/main/java/itc/converters/ElastixSimilarity2DToAffineTransform2D.java
+++ b/src/main/java/itc/converters/ElastixSimilarity2DToAffineTransform2D.java
@@ -73,22 +73,22 @@ public class ElastixSimilarity2DToAffineTransform2D
 
 		// convert
 		//
-		final double[] rotationCentrePositive = new double[ 2 ];
-		final double[] rotationCentreNegative = new double[ 2 ];
+		final double[] rotationCenterPositive = new double[ 2 ];
+		final double[] rotationCenterNegative = new double[ 2 ];
 
 		for ( int d = 0; d < 2; ++d )
 		{
-			rotationCentrePositive[ d ] = rotationCenterInMillimeters[ d ];
-			rotationCentreNegative[ d ] = - rotationCenterInMillimeters[ d ];
+			rotationCenterPositive[ d ] = rotationCenterInMillimeters[ d ];
+			rotationCenterNegative[ d ] = - rotationCenterInMillimeters[ d ];
 		}
 
 		final AffineTransform2D transform2D = new AffineTransform2D();
 
-		// rotate around rotation centre
+		// rotate around rotation center
 		//
 
-		// translate to rotation centre
-		transform2D.translate( rotationCentreNegative );
+		// translate to rotation center
+		transform2D.translate( rotationCenterNegative );
 
 		// rotate
 		transform2D.rotate( angle );
@@ -96,10 +96,10 @@ public class ElastixSimilarity2DToAffineTransform2D
 		// scale isotropically
 		transform2D.scale( scalingFactor );
 
-		// move image centre back
-		final AffineTransform2D translateBackFromRotationCentre = new AffineTransform2D();
-		translateBackFromRotationCentre.translate( rotationCentrePositive );
-		transform2D.preConcatenate( translateBackFromRotationCentre );
+		// move image center back
+		final AffineTransform2D translateBackFromRotationCenter = new AffineTransform2D();
+		translateBackFromRotationCenter.translate( rotationCenterPositive );
+		transform2D.preConcatenate( translateBackFromRotationCenter );
 
 		// translate
 		//

--- a/src/main/java/itc/converters/ElastixSimilarity3DToAffineTransform3D.java
+++ b/src/main/java/itc/converters/ElastixSimilarity3DToAffineTransform3D.java
@@ -71,13 +71,13 @@ public class ElastixSimilarity3DToAffineTransform3D
 
 		// convert
 		//
-		final double[] rotationCentrePositive = new double[ 3 ];
-		final double[] rotationCentreNegative = new double[ 3 ];
+		final double[] rotationCenterPositive = new double[ 3 ];
+		final double[] rotationCenterNegative = new double[ 3 ];
 
 		for ( int d = 0; d < 3; ++d )
 		{
-			rotationCentrePositive[ d ] = rotationCenterInMillimeters[ d ];
-			rotationCentreNegative[ d ] = - rotationCenterInMillimeters[ d ];
+			rotationCenterPositive[ d ] = rotationCenterInMillimeters[ d ];
+			rotationCenterNegative[ d ] = - rotationCenterInMillimeters[ d ];
 		}
 
 		final AffineTransform3D transform3D = new AffineTransform3D();
@@ -85,8 +85,8 @@ public class ElastixSimilarity3DToAffineTransform3D
 		// rotate and scale
 		//
 
-		// translate to rotation centre
-		transform3D.translate( rotationCentreNegative );
+		// translate to rotation center
+		transform3D.translate( rotationCenterNegative );
 
 		// rotate
 		final AffineTransform3D rotate = new AffineTransform3D();
@@ -103,11 +103,11 @@ public class ElastixSimilarity3DToAffineTransform3D
 		// scale
 		transform3D.scale( scalingFactor );
 
-		// translate back from rotation centre
-		final AffineTransform3D translateBackFromRotationCentre = new AffineTransform3D();
-		translateBackFromRotationCentre.translate( rotationCentrePositive );
+		// translate back from rotation center
+		final AffineTransform3D translateBackFromRotationCenter = new AffineTransform3D();
+		translateBackFromRotationCenter.translate( rotationCenterPositive );
 
-		transform3D.preConcatenate( translateBackFromRotationCentre );
+		transform3D.preConcatenate( translateBackFromRotationCenter );
 
 		// translate
 		//

--- a/src/main/java/itc/converters/ElastixSimilarity3DToAffineTransform3D.java
+++ b/src/main/java/itc/converters/ElastixSimilarity3DToAffineTransform3D.java
@@ -61,6 +61,59 @@ public class ElastixSimilarity3DToAffineTransform3D
 	 */
 	public static AffineTransform3D convert( ElastixSimilarityTransform3D elastixSimilarityTransform3D )
 	{
-		throw new UnsupportedOperationException("PR appreciated!");
+		// fetch values from elastix transform
+		//
+		final double[][] rotationMatrix = elastixSimilarityTransform3D.getRotationMatrix();
+		final double scalingFactor = elastixSimilarityTransform3D.getScalingFactor();
+		final double[] rotationCenterInMillimeters = elastixSimilarityTransform3D.getRotationCenterInMillimeters();
+		final double[] translationInMillimeters = elastixSimilarityTransform3D.getTranslationInMillimeters();
+
+
+		// convert
+		//
+		final double[] rotationCentrePositive = new double[ 3 ];
+		final double[] rotationCentreNegative = new double[ 3 ];
+
+		for ( int d = 0; d < 3; ++d )
+		{
+			rotationCentrePositive[ d ] = rotationCenterInMillimeters[ d ];
+			rotationCentreNegative[ d ] = - rotationCenterInMillimeters[ d ];
+		}
+
+		final AffineTransform3D transform3D = new AffineTransform3D();
+
+		// rotate and scale
+		//
+
+		// translate to rotation centre
+		transform3D.translate( rotationCentreNegative );
+
+		// rotate
+		final AffineTransform3D rotate = new AffineTransform3D();
+		for ( int row = 0; row < 3; row++ )
+		{
+			for ( int col = 0; col < 3; col++ )
+			{
+				rotate.set( rotationMatrix[row][col], row, col );
+			}
+		}
+
+		transform3D.preConcatenate( rotate );
+
+		// translate back from rotation centre
+		final AffineTransform3D translateBackFromRotationCentre = new AffineTransform3D();
+		translateBackFromRotationCentre.translate( rotationCentrePositive );
+
+		transform3D.preConcatenate( translateBackFromRotationCentre );
+
+		// TODO - where should scaling go?
+		// scale
+		transform3D.scale( scalingFactor );
+
+		// translate
+		//
+		transform3D.translate( translationInMillimeters );
+
+		return transform3D;
 	}
 }

--- a/src/main/java/itc/converters/ElastixSimilarity3DToAffineTransform3D.java
+++ b/src/main/java/itc/converters/ElastixSimilarity3DToAffineTransform3D.java
@@ -100,15 +100,14 @@ public class ElastixSimilarity3DToAffineTransform3D
 
 		transform3D.preConcatenate( rotate );
 
+		// scale
+		transform3D.scale( scalingFactor );
+
 		// translate back from rotation centre
 		final AffineTransform3D translateBackFromRotationCentre = new AffineTransform3D();
 		translateBackFromRotationCentre.translate( rotationCentrePositive );
 
 		transform3D.preConcatenate( translateBackFromRotationCentre );
-
-		// TODO - where should scaling go?
-		// scale
-		transform3D.scale( scalingFactor );
 
 		// translate
 		//

--- a/src/main/java/itc/transforms/elastix/ElastixSimilarityTransform2D.java
+++ b/src/main/java/itc/transforms/elastix/ElastixSimilarityTransform2D.java
@@ -29,4 +29,27 @@
 package itc.transforms.elastix;
 
 public class ElastixSimilarityTransform2D extends ElastixSimilarityTransform {
+
+    public double getScalingFactor() {
+        final double scalingFactor = TransformParameters[0];
+        return scalingFactor;
+    }
+
+    public double[] getRotationAnglesInRadians()
+    {
+        final double[] rotation = {0,0,TransformParameters[ 1 ]}; // Rotation around Z only - returns 0 in both X and Y axis
+        return rotation;
+    }
+
+    public double[] getTranslationInMillimeters()
+    {
+        final double[] translation = { TransformParameters[ 2 ], TransformParameters[ 3 ]};
+        return translation;
+    }
+
+    public double[] getRotationCenterInMillimeters()
+    {
+        final double[] rotationCenter = { CenterOfRotationPoint[ 0 ], CenterOfRotationPoint[ 1 ]};
+        return rotationCenter;
+    }
 }

--- a/src/main/java/itc/transforms/elastix/ElastixSimilarityTransform3D.java
+++ b/src/main/java/itc/transforms/elastix/ElastixSimilarityTransform3D.java
@@ -54,8 +54,6 @@ public class ElastixSimilarityTransform3D extends ElastixSimilarityTransform {
         // the scalar part (w) from this
         // based on elastix / itk source code:
         // https://github.com/SuperElastix/elastix/blob/c3a254562d6801f1a34a2de0ec324c10632b5884/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx#L126
-        // https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/Core/Common/include/itkVersor.hxx#L444
-        // https://itk.org/Doxygen/html/classitk_1_1Versor.html#a72a0cf968370f95dac5bac84a01f93a0
 
         double[] axis = new double[3];
         axis[0] = TransformParameters[0];
@@ -70,6 +68,9 @@ public class ElastixSimilarityTransform3D extends ElastixSimilarityTransform {
                 axis[i] = axis[i] / (norm + epsilon * norm);
             }
         }
+
+        // https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/Core/Common/include/itkVersor.hxx#L444
+        // https://itk.org/Doxygen/html/classitk_1_1Versor.html#a72a0cf968370f95dac5bac84a01f93a0
 
         double sinangle2 = getNorm( axis );
         double cosangle2 = sqrt( 1 - sinangle2 * sinangle2);

--- a/src/main/java/itc/transforms/elastix/ElastixSimilarityTransform3D.java
+++ b/src/main/java/itc/transforms/elastix/ElastixSimilarityTransform3D.java
@@ -28,5 +28,75 @@
  */
 package itc.transforms.elastix;
 
+import static java.lang.Math.sqrt;
+import static net.imglib2.util.LinAlgHelpers.quaternionToR;
+
 public class ElastixSimilarityTransform3D extends ElastixSimilarityTransform {
+
+    private double getNorm( double[] vector )
+    {
+        double norm = 0;
+        for ( int i=0; i<vector.length; i++ ) {
+            norm += vector[i]*vector[i];
+        }
+
+        if (norm > 0)
+        {
+            norm = sqrt(norm);
+        }
+
+        return norm;
+    }
+
+    public double[][] getRotationMatrix()
+    {
+        // transform parameters only gives the first 3 parts (x, y, z) of the unit quaternion - we must calculate
+        // the scalar part (w) from this
+        // based on elastix / itk source code:
+        // https://github.com/SuperElastix/elastix/blob/c3a254562d6801f1a34a2de0ec324c10632b5884/Common/Transforms/itkAdvancedSimilarity3DTransform.hxx#L126
+        // https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/Core/Common/include/itkVersor.hxx#L444
+        // https://itk.org/Doxygen/html/classitk_1_1Versor.html#a72a0cf968370f95dac5bac84a01f93a0
+
+        double[] axis = new double[3];
+        axis[0] = TransformParameters[0];
+        axis[1] = TransformParameters[1];
+        axis[2] = TransformParameters[2];
+        double norm = getNorm( axis );
+
+        double epsilon = 1e-10;
+        if (norm >= 1.0 - epsilon)
+        {
+            for ( int i=0; i<axis.length; i++ ) {
+                axis[i] = axis[i] / (norm + epsilon * norm);
+            }
+        }
+
+        double sinangle2 = getNorm( axis );
+        double cosangle2 = sqrt( 1 - sinangle2 * sinangle2);
+
+        double[] unitQuaternion = new double[]{ axis[0], axis[1], axis[2], cosangle2 };
+
+        final double[][] matrix = new double[3][3];
+        quaternionToR( unitQuaternion, matrix );
+
+        return matrix;
+    }
+
+    public double getScalingFactor()
+    {
+        final double scalingFactor = TransformParameters[6];
+        return scalingFactor;
+    }
+
+    public double[] getTranslationInMillimeters()
+    {
+        final double[] translation = { TransformParameters[ 3 ], TransformParameters[ 4 ], TransformParameters[ 5 ]};
+        return translation;
+    }
+
+    public double[] getRotationCenterInMillimeters()
+    {
+        final double[] rotationCenter = { CenterOfRotationPoint[ 0 ], CenterOfRotationPoint[ 1 ], CenterOfRotationPoint[ 2 ]};
+        return rotationCenter;
+    }
 }

--- a/src/main/java/itc/transforms/elastix/ElastixSimilarityTransform3D.java
+++ b/src/main/java/itc/transforms/elastix/ElastixSimilarityTransform3D.java
@@ -74,7 +74,7 @@ public class ElastixSimilarityTransform3D extends ElastixSimilarityTransform {
         double sinangle2 = getNorm( axis );
         double cosangle2 = sqrt( 1 - sinangle2 * sinangle2);
 
-        double[] unitQuaternion = new double[]{ axis[0], axis[1], axis[2], cosangle2 };
+        double[] unitQuaternion = new double[]{ cosangle2, axis[0], axis[1], axis[2] };
 
         final double[][] matrix = new double[3][3];
         quaternionToR( unitQuaternion, matrix );

--- a/src/test/resources/elastix/TransformParameters.Similarity2D.txt
+++ b/src/test/resources/elastix/TransformParameters.Similarity2D.txt
@@ -1,0 +1,30 @@
+(Transform "SimilarityTransform")
+(NumberOfParameters 4)
+(TransformParameters 0.689711 0.174234 21.684118 16.818707)
+(InitialTransformParametersFileName "NoInitialTransform")
+(HowToCombineTransforms "Compose")
+
+// Image specific
+(FixedImageDimension 2)
+(MovingImageDimension 2)
+(FixedInternalImagePixelType "float")
+(MovingInternalImagePixelType "float")
+(Size 186 226)
+(Index 0 0)
+(Spacing 1.0000000000 1.0000000000)
+(Origin 0.0000000000 0.0000000000)
+(Direction 1.0000000000 0.0000000000 0.0000000000 1.0000000000)
+(UseDirectionCosines "false")
+
+// SimilarityTransform specific
+(CenterOfRotationPoint 94.2094861492 111.0858216134)
+
+// ResampleInterpolator specific
+(ResampleInterpolator "FinalLinearInterpolator")
+
+// Resampler specific
+(Resampler "DefaultResampler")
+(DefaultPixelValue 0.000000)
+(ResultImageFormat "mhd")
+(ResultImagePixelType "unsigned char")
+(CompressResultImage "false")


### PR DESCRIPTION
This adds converters for:
-ElastixSimilarity2DToAffineTransform2D
-ElastixSimilarity3DToAffineTransform3D

For issue: https://github.com/image-transform-converters/image-transform-converters/issues/32

I tested this with some simple similarity examples, and the results looked good. I'm not entirely convinced about the order of rotation / scaling in these though - so it'd be great to get a second opinion on this!